### PR TITLE
Remove unnecessary/confusing dynamic coding

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -161,15 +161,11 @@ Another countermeasure is to _save user-specific properties in the session_, ver
 
 NOTE: _Sessions that never expire extend the time-frame for attacks such as cross-site request forgery (CSRF), session hijacking and session fixation._
 
-One possibility is to set the expiry time-stamp of the cookie with the session id. However the client can edit cookies that are stored in the web browser so expiring sessions on the server is safer. Here is an example of how to _expire sessions in a database table_. Call `Session.sweep("20 minutes")` to expire sessions that were used longer than 20 minutes ago.
+One possibility is to set the expiry time-stamp of the cookie with the session id. However the client can edit cookies that are stored in the web browser so expiring sessions on the server is safer. Here is an example of how to _expire sessions in a database table_. Call `Session.sweep(20.minutes)` to expire sessions that were used longer than 20 minutes ago.
 
 ```ruby
 class Session < ActiveRecord::Base
   def self.sweep(time = 1.hour)
-    if time.is_a?(String)
-      time = time.split.inject { |count, unit| count.to_i.send(unit) }
-    end
-
     delete_all "updated_at < '#{time.ago.to_s(:db)}'"
   end
 end


### PR DESCRIPTION
This is a critical security document and introducing fancy ruby tricks for string interpretation seems like clouding the issue. The cleaned up example should hopefully suffice. 