### PR TITLE
ActiveRecord Attributes API code fix

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -122,7 +122,7 @@ module ActiveRecord
       #
       #   class MoneyType < ActiveRecord::Type::Integer
       #     def cast(value)
-      #       if value.include?('$')
+      #       if !value.kind_of(Numeric) && value.include?('$')
       #         price_in_dollars = value.gsub(/\$/, '').to_f
       #         super(price_in_dollars * 100)
       #       else


### PR DESCRIPTION
I came across this while trying it out, with the provided code the
`MoneyType` does not save as it complains that `Fixnum` does not define
`include?`. I think the sensible thing is to check if it already is a
`Numeric`.